### PR TITLE
Doc: Improve README for macOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,52 @@ git clone -b WorkingBranch https://github.com/nibeditabh/GraphDSL.git
 cd GraphDSL/src
 make
 ```
+
+# How to Build (Mac OS | Tested on M1)
+
+By default, MacOS comes with the `clang` compiler, which can cause syntax errors when running the `make` command due to differences between `gcc` and `clang` semantics. To resolve this, follow these steps:
+
+## Installation:
+
+1. Install `gcc` using Homebrew:
+
+   ```sh
+   brew install gcc
+   ```
+
+2. Check the installation location of the `g++` binaries:
+
+   ```sh
+   which brew
+   ll /opt/homebrew/bin/g++-*
+   ```
+
+3. Create symbolic links to the installed version, (presumes that the above command returns gcc-13):
+
+   ```sh
+   sudo ln -sf /opt/homebrew/bin/gcc-13 /usr/local/bin/gcc
+   sudo ln -sf /opt/homebrew/bin/g++-13 /usr/local/bin/g++
+   sudo ln -sf /opt/homebrew/bin/c++-13 /usr/local/bin/c++
+   sudo ln -sf /opt/homebrew/bin/cpp-13 /usr/local/bin/cpp
+   ```
+
+   Note: Modifying anything in `/usr/bin/*` is discouraged and may require disabling SIP (System Integrity Protection). Therefore, we create symlinks to `/usr/local/bin/*`.
+
+4. After installation, check the versions:
+
+   ```sh
+   g++ --version # Should return clang version
+   g++-13 --version # Should return (Homebrew GCC)
+   ```
+
+5. Update the Makefile (`StarPlat/src/Makefile`) to use the symlinked `g++`:
+
+   ```make
+   CC = /usr/local/bin/g++
+   ```
+6. Add `%token return_func` in the file `lrparser.y` (`StarPlat/src/parser/lrparser.y`)
+ 
+
 # How to generate
 ```
 # Step 3. Generate files from DSL files.  

--- a/README.md
+++ b/README.md
@@ -183,6 +183,107 @@ pgc++ -std=c++14 ../graphcode/generated_OpenACC/sssp_dslV2.cu -I .. -o ssspAcc.o
 
 ```
 
+# Miscellaneous
+## Installing Boost Libraries to run StarPlat for MPI
+
+On the root directory of `StarPlat`, running the command:
+
+```sh
+grep -r '<boost/' .
+```
+
+shows the files that use boost. This section provides a walkthrough of building, installing, and linking the boost libraries and source to create a program. The workflow has been tested on an arm64 architecture with a 64-bit address type on a Mac machine. While this guide is compiled from various sources, for a comprehensive understanding, please refer to the official boost documentation.
+
+Our main goal is to build the following file with `mpic++` and run with `mpirun`:
+
+```c++
+#include <iostream>
+#include <boost/mpi/environment.hpp>
+#include <boost/mpi/communicator.hpp>
+
+namespace mpi = boost::mpi;
+
+int main() {
+    mpi::environment env;
+    mpi::communicator world;
+    std::cout << "I am process " << world.rank() << " of " << world.size() << "." << std::endl;
+    return 0;
+}
+```
+
+The default compiler that comes with MacOS is clang, and StarPlat is built on `gcc`. Note that a C++ library compiled with GCC is not compatible with Clang and vice versa. So, we will build the libraries and code exclusively on one platform.
+
+There are options to compile boost as a universal library agnostic to architecture (discussed [here](https://stackoverflow.com/questions/64553398/compile-boost-as-universal-library-intel-and-apple-silicon-architectures)), but for brevity, this walkthrough aims to run it on gcc/g++.
+
+We will be building the boost library from the source, providing more autonomy and control over packages and libraries, and installation directories from where we can include headers and link libraries.
+
+- **Step 1**: Download the tar file from boost/downloads.
+- **Step 2**: Extract the tar file to a location using the command `tar -xvf boost.tar.gz`.
+- **Step 3**: Create a directory anywhere with `mkdir -p /path/to/boost_version`.
+- **Step 4**: Navigate to the extracted boost directory.
+- **Step 5**: Run `./bootstrap.sh --prefix=/path/to/boost_version` to extract all the headers and binaries in the specified prefix location.
+- **Step 6**: The bootstrap.sh will create a file called `project-config.jam`.
+- **Step 7**: In the `project-config.jam` file, comment out the section related to the compiler configuration.
+
+```jam
+# Compiler configuration. This definition will be used unless
+# you already have defined some toolsets in your user-config.jam
+# file.
+# if ! clang in [ feature.values <toolset> ]
+# {
+#    using clang ;
+# }
+
+# project : default-build <toolset>clang ;
+```
+
+- **Step 8**: Configure the project-config.jam to use gcc.
+
+```jam
+using gcc : <version> : /path/to/gcc
+# Example
+using gcc : 13.2 : /usr/local/bin/gcc
+```
+
+- **Step 9**: Install MPI by following the steps [here](https://docs.open-mpi.org/en/v5.0.x/installing-open-mpi/quickstart.html).
+- **Step 10**: Add the following line to the `project-config.jam` file (notice the space between mpi and ;).
+
+```jam
+using mpi ;
+```
+
+- **Step 11**: Run the command `./b2 cxxflags=-std=c++17 install` to build boost with the standard library of choice and install it. If you encounter permission denied errors, use `sudo` before the command.
+
+- **Step 12**: If your editor's autocomplete looks for environment variables for autocompletion and code completion, run:
+
+```sh
+export DYLD_LIBRARY_PATH=/path/to/boost/lib/:$DYLD_LIBRARY_PATH
+```
+
+- **Step 13**: Copy the following content:
+
+```c++
+#include <iostream>
+#include <boost/mpi/environment.hpp>
+#include <boost/mpi/communicator.hpp>
+
+namespace mpi = boost::mpi;
+
+int main() {
+    mpi::environment env;
+    mpi::communicator world;
+    std::cout << "I am process " << world.rank() << " of " << world.size() << "." << std::endl;
+    return 0;
+}
+```
+
+```sh
+OMPI_CXX=g++ mpic++ -I/Users/durwasa/boost/include -L/Users/durwasa/boost/lib helloworld.cpp -o helloworld -lboost_mpi
+```
+
+The `OMPI_CXX` sets the environment variable to `gcc` instead of `clang` (since `mpic++` has been installed using Homebrew/MacPorts). `-I` includes the header files, `-L` links the library, and `-lboost_mpi` links the boost.mpi, which we configured using our .jam file.
+
+- **Step 14**: Run the command `OMPI_CXX=g++ mpirun helloworld`. If the default compiler in the system is `gcc`, omit the `OMPI_CXX` flag. `mpicxx` and other variants are technically compiler wrappers that translate the compiler commands and inject flags into it. Using the `OMPI_CXX` flag specifies which C++ compiler it should use while injecting the flags. Learn more about compiler wrappers [here](https://www.ibm.com/docs/en/smpi/10.2?topic=administering-compiling-applications).
 
 Graph DSL for basic graph algorithms 
 - Phase1 (static)  **SSSP, BC, PR, and TC**

--- a/graphcode/generated_mpi/main.cc
+++ b/graphcode/generated_mpi/main.cc
@@ -2,6 +2,7 @@
 #include"PageRankDSLV2.h"
 #include"triangle_counting_dsl.h"
 #include"sssp_dslV3.h"
+#include"sssp_dslV2.h"
 #include"bc_dslV2.h"
 
 int main(int argc, char *argv[])
@@ -11,14 +12,14 @@ int main(int argc, char *argv[])
     boost::mpi::communicator world;
     
     //printf("program started\n"); 
-    Graph graph(argv[1],world);
+    Graph graph(argv[1], world);
     world.barrier();
 
     
     // Triangle Counting
     //need to add print statement in generated code to check the value of triangle count
     
-    Compute_TC(graph, world );
+    // Compute_TC(graph, world );
     
 
     
@@ -31,9 +32,11 @@ int main(int argc, char *argv[])
     {
         printf("%d %d\n", i, dist.getValue(i));
     }*/
-    
 
-
+    // TODO: sssp DSLV2
+    // int src = 0;
+    // NodeProperty<int> dist;
+    // Compute_SSSP(graph, dist, graph.weights, 0, world);
 
     //PageRank
     /*float beta = 0.01;
@@ -55,7 +58,5 @@ int main(int argc, char *argv[])
     {
         printf("%d %f\n", i, BC.getValue(i));
     }*/
-    
-    world.barrier();
     return 0;
 }

--- a/graphcode/staticDSLCodes/sssp_dslV2
+++ b/graphcode/staticDSLCodes/sssp_dslV2
@@ -13,7 +13,7 @@ function Compute_SSSP(Graph g, propNode<int> dist, propEdge<int> weight, node sr
                forall(nbr in g.neighbors(v).filter(modified1 == True))
                {
                     edge e = g.get_edge(v, nbr);
-                    <nbr.dist, nbr.modified> = <Min(nbr.dist, v.dist + e.weight), True>;
+                    <nbr.dist, nbr.modified1> = <Min(nbr.dist, v.dist + e.weight), True>;
                }
           }
      }

--- a/src/backends/backend_mpi/dsl_cpp_statement_generator.cpp
+++ b/src/backends/backend_mpi/dsl_cpp_statement_generator.cpp
@@ -724,7 +724,7 @@ namespace spmpi {
                     TableEntry* tableEntry = filterId != NULL ? filterId->getSymbolInfo() : NULL;
                     if (tableEntry != NULL && tableEntry->getId()->get_fp_association()) 
                     {
-                        sprintf(strBuffer,"%s.remeberHistory()", filterId->getIdentifier());
+                        sprintf(strBuffer,"%s.rememberHistory();", filterId->getIdentifier());
                         if(!already_remebered)
                             main.pushstr_newL(strBuffer);
 

--- a/src/parser/lrparser.y
+++ b/src/parser/lrparser.y
@@ -67,6 +67,7 @@
 %token <fval> FLOAT_NUM
 %token <bval> BOOL_VAL
 %token <cval> CHAR_VAL
+%token return_func
 
 %type <node> function_def function_data  return_func function_body param
 %type <pList> paramList


### PR DESCRIPTION
### PR Description:
This PR includes the following changes:

#### README:

* Improved the README to provide instructions for building the project on macOS and tested the workflow on an M1 machine. The README now includes comprehensive instructions for installing Boost Libraries to run Boost.MPI
* Fixed the generated code error for sssp in MPI by fixing the typo errors in `dsl_cpp_statement_generator.cpp` and `staticDSLCode`
* Added code to initialize and compute Single Source Shortest Path (SSSP) using DSLV2. This resolves the previous error encountered with the `Compute_SSSP` function, incorrect argument type to call `Compute_SSSP`


#### lrparser.y:

* Introduced a new token in the lrparser.y file to address the following error during the build phase
> lrparser.y:71.42-52: symbol return_func is used, but is not defined as a token and has no rules 






